### PR TITLE
Hide extra scrollbars in Firefox

### DIFF
--- a/src/frontend/src/TransactionList.js
+++ b/src/frontend/src/TransactionList.js
@@ -77,7 +77,7 @@ export default function TransactionList(props) {
     return (
         <>
             <Header back_visibility={back_visibility} title="Transactions"></Header>
-            <Box sx={{ pb: 8 }}>
+            <Box sx={{ pb: 8 }} style={{ "overflow-y": "hidden" }}>
                 <TableContainer>
                     <Table className="txnList" style={{ "width": "100%" }}>
                         <TableHead>


### PR DESCRIPTION
In Firefox, extra scrollbars were being displayed on the transactions list. This PR hides them.