### PR TITLE
Add support for SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+database.sqlite3

--- a/README.md
+++ b/README.md
@@ -8,20 +8,13 @@ Use [Firefly III](https://github.com/firefly-iii/firefly-iii) to store transacti
 
 ## Installation
 
-You'll need to create a database and user for `lychnos`. I'm using MySQL:
+You can run `lychnos` with SQLite or MySQL/MariaDB. Configure your database connection string in `.env`. If no connection string is provided, a SQLite database will be created in the working directory.
 
-```mysql
-CREATE USER 'lychnos_user'@'localhost' IDENTIFIED BY 'password';
-CREATE DATABASE lychnos_db;
-GRANT ALL PRIVILEGES ON lychnos_db.* TO 'lychnos_user'@'localhost';
-FLUSH PRIVILEGES;
-```
-
-Then, copy `.env.sample` in `src/backend` to `.env` and update the database connection string. Be sure to load the environment variables from `.env` before starting `lychnos`. The easiest way to start the backend is to `go run .` in `src/backend`. Since the application does not provide authentication, a reverse proxy should provide access control.
+Be sure to load the environment variables from `.env` before starting `lychnos`. The easiest way to start the backend is to `go run .` in `src/backend`. Since the application does not provide authentication, a reverse proxy should provide access control.
 
 ## Deployment
 
-I put the backend behind an nginx reverse proxy for the `/api` path, and serve the React frontend under `/app` (statically with nginx) on the same domain.
+I put the backend behind an nginx reverse proxy for the `/api` path, and serve the React frontend under `/app` (statically with nginx) on the same domain. You'll want both to be on the same host so that you don't have trouble with CORS.
 
 Relevant excerpt from my nginx config:
 

--- a/src/backend/.env.sample
+++ b/src/backend/.env.sample
@@ -1,3 +1,11 @@
-DSN=username:password@protocol(address)/dbname?parseTime=true
+# Configure a database connection by uncommenting and updating one of the
+# lines below. (If unset, a SQLite database will be created in the working
+# directory.)
+#SQLITE_DSN="file:database.db?cache=shared&mode=memory"
+#MYSQL_DSN=username:password@protocol(address)/dbname?parseTime=true
+
+# Provide a valid personal access token from Firefly-III
 FIREFLY_TOKEN=personal_access_token_from_firefly-iii
+
+# Provide the URL to your Firefly-III installation
 FIREFLY_URL=firefly-iii-base-url

--- a/src/backend/db.go
+++ b/src/backend/db.go
@@ -7,12 +7,51 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
 )
 
-func connect() *sql.DB {
-	db, err := sql.Open("mysql", os.Getenv("DSN"))
+type connectionType int
+
+const (
+	connectionTypeSQLite connectionType = iota
+	connectionTypeMySQL
+)
+
+var connectionTypeStrings = [...]string{
+	connectionTypeSQLite: "sqlite",
+	connectionTypeMySQL:  "mysql",
+}
+
+func (c connectionType) String() string {
+	if int(c) < 0 || int(c) >= len(connectionTypeStrings) {
+		return ""
+	}
+	return connectionTypeStrings[int(c)]
+}
+
+type connectionString struct {
+	DSN  string
+	Type connectionType
+}
+
+// connect connects to the database, based on the connection string provided by
+// the user. If no connection string was provided, attempt to create a SQLite
+// database.
+func connect() (*sql.DB, error) {
+	var db *sql.DB
+
+	dsn, err := getDSN()
 	if err != nil {
-		panic(err)
+		return nil, err
+	}
+
+	if dsn.DSN == "" {
+		db, err = createSQLite()
+	} else {
+		db, err = sql.Open(dsn.Type.String(), dsn.DSN)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	db.SetConnMaxLifetime(time.Minute * 3)
@@ -22,17 +61,57 @@ func connect() *sql.DB {
 	// Validate database connection
 	err = db.Ping()
 	if err != nil {
-		fmt.Printf("Could not connect to database: %s", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("could not connect to database: %s", err)
 	}
 
-	return db
+	// Set up tables
+	err = setupDB(&dsn, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize tables: %s", err)
+	}
+
+	return db, nil
+}
+
+func createSQLite() (*sql.DB, error) {
+	// create the DB
+	db, err := sql.Open("sqlite3", "./database.sqlite3")
+	return db, err
+}
+
+// getDSN reads the database connection string from the environment, returning
+// it along with its type.
+func getDSN() (connectionString, error) {
+	var (
+		dsn                 connectionString
+		mysqlDSN, sqliteDSN string
+	)
+	mysqlDSN = os.Getenv("MYSQL_DSN")
+	sqliteDSN = os.Getenv("SQLITE_DSN")
+
+	if mysqlDSN != "" && sqliteDSN != "" {
+		return dsn, fmt.Errorf("MYSQL_DSN and SQLITE_DSN cannot both be set")
+	}
+
+	if mysqlDSN != "" {
+		dsn.DSN = mysqlDSN
+		dsn.Type = connectionTypeMySQL
+	} else {
+		dsn.DSN = sqliteDSN // okay if empty, will create SQLite database
+		dsn.Type = connectionTypeSQLite
+	}
+
+	return dsn, nil
 }
 
 // setupDB will create the tables that lychnos uses to store its budget data, if
 // they do not already exist.
-func setupDB(db *sql.DB) {
-	q := []string{`
+func setupDB(dsn *connectionString, db *sql.DB) error {
+	var q []string
+
+	if dsn != nil && dsn.Type == connectionTypeMySQL {
+		// MySQL
+		q = []string{`
 CREATE TABLE IF NOT EXISTS budgets (
 	id INT NOT NULL AUTO_INCREMENT,
 	start DATETIME NOT NULL,
@@ -50,12 +129,31 @@ CREATE TABLE IF NOT EXISTS category_budgets (
 	FOREIGN KEY ( budget ) REFERENCES budgets( id )
 );
 `}
+	} else {
+		// SQLite
+		q = []string{`
+CREATE TABLE IF NOT EXISTS budgets (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	start DATETIME NOT NULL,
+	end DATETIME NOT NULL,
+	reporting_interval INT NOT NULL
+);
+`, `
+CREATE TABLE IF NOT EXISTS category_budgets (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	budget INT,
+	category INT,
+	amount DECIMAL(12,4),
+	FOREIGN KEY ( budget ) REFERENCES budgets( id )
+);
+		`}
+	}
 
 	for _, s := range q {
 		_, err := db.Exec(s)
 		if err != nil {
-			fmt.Printf("Could not initialize database tables: %s", err)
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
 }

--- a/src/backend/db_test.go
+++ b/src/backend/db_test.go
@@ -16,7 +16,7 @@ func TestSetupDB(t *testing.T) {
 	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS budgets.*`).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS category_budgets.*`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	setupDB(db)
+	setupDB(nil, db)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)

--- a/src/backend/go.mod
+++ b/src/backend/go.mod
@@ -6,4 +6,7 @@ require github.com/go-sql-driver/mysql v1.6.0
 
 require github.com/DATA-DOG/go-sqlmock v1.5.0
 
-require github.com/shopspring/decimal v1.3.1
+require (
+	github.com/mattn/go-sqlite3 v1.14.15
+	github.com/shopspring/decimal v1.3.1
+)

--- a/src/backend/go.sum
+++ b/src/backend/go.sum
@@ -2,5 +2,7 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
+github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -14,10 +14,18 @@ import (
 )
 
 func main() {
-	db := connect()
-	setupDB(db)
+	db, err := connect()
+	if err != nil {
+		fmt.Printf("Failed to initialize database: %s\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
 
-	f, err := firefly.New(&http.Client{Timeout: time.Second * 30}, os.Getenv("FIREFLY_TOKEN"), os.Getenv("FIREFLY_URL"))
+	f, err := firefly.New(
+		&http.Client{Timeout: time.Second * 30},
+		os.Getenv("FIREFLY_TOKEN"),
+		os.Getenv("FIREFLY_URL"),
+	)
 	if err != nil {
 		fmt.Printf("Could not initialize Firefly-III client: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Implement support for SQLite, along-side MySQL/MariaDB. While an existing Firefly-III installation is likely to be running on MySQL, SQLite is a simpler and lighter alternative if `lychnos` is running on a different host. Since we're also automatically creating the database file if none is specified, this simplifies setup for new users. Eventually, I would like to be able to distribute `lychnos` in a Docker image, and removing the dependency on MySQL is a first step to accomplish this.

Caveat: personally I'm using MySQL, so SQLite is not yet thoroughly tested.

Fixes #26.