### PR TITLE
Build and run with Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: cd src/backend && go test ./...
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.env
-database.sqlite3
+src/backend/.env
+src/backend/database.sqlite3
+src/backend/backend

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/backend/.env
 src/backend/database.sqlite3
 src/backend/backend
+src/frontend/build

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ dev: backend.watch frontend.watch
 clean:
 	rm src/backend/backend
 	rm src/backend/database.sqlite3
+	rm src/frontend/build
 	rm src/frontend/node_modules
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+backend:
+	cd src/backend && go build .
+
+backend.watch:
+	cd src/backend && go run github.com/cespare/reflex@latest -s -r '\.go$$' go run github.com/joho/godotenv/cmd/godotenv@latest go run .
+
+frontend: frontend.install
+	npm run build
+
+frontend.install:
+	cd src/frontend && npm install
+
+frontend.watch: frontend.install
+	cd src/frontend && BROWSER=none npm run start
+
+dev: backend.watch frontend.watch
+
+clean:
+	rm src/backend/backend
+	rm src/backend/database.sqlite3
+	rm src/frontend/node_modules
+
+test:
+	cd src/backend && go test ./...
+
+.PHONY: backend backend.watch frontend frontend.install frontend.watch dev clean test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ backend.watch:
 	cd src/backend && go run github.com/cespare/reflex@latest -s -r '\.go$$' go run github.com/joho/godotenv/cmd/godotenv@latest go run .
 
 frontend: frontend.install
-	npm run build
+	cd src/frontend && npm run build
 
 frontend.install:
 	cd src/frontend && npm install

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Use [Firefly III](https://github.com/firefly-iii/firefly-iii) to store transacti
 
 ## Local development
 
-Make sure you have a working installation of `firefly-iii`.
+Make sure you have a working installation of `firefly-iii`. In `src/backend`, copy `.env.sample` to `.env` and update the `firefly-iii` API key and base URL. The database connection string is optional (if unspecified, a SQLite file will be created in `src/backend`).
 
-Set the `firefly-iii` API key and base URL environment variables (see src/backend/.env.sample), then start the backend server (listens on localhost:8080) with: `go run .`
-
-For the front-end, `npm install` in src/frontend/, then `npm run start`. The front-end will automatically proxy API requests to the backend.
+Then, simply `make -j2 dev`, which will start the backend and frontend and restart either if their source files are changed.
 
 ## Installation
 
 You can run `lychnos` with SQLite or MySQL/MariaDB. Configure your database connection string in `.env`. If no connection string is provided, a SQLite database will be created in the working directory.
 
 Be sure to load the environment variables from `.env` before starting `lychnos`. The easiest way to start the backend is to `go run .` in `src/backend`. Since the application does not provide authentication, a reverse proxy should provide access control.
+
+You can build the backend with `make backend` (`backend` binary in `src/backend`) and the frontend with `make frontend` (`build` folder in `src/frontend`).
 
 ## Deployment
 


### PR DESCRIPTION
Make local development easier by adding a Makefile. To start the frontend and backend, simply `make -j2 dev`.