### PR TITLE
Add safe area padding to bottom of page

### DIFF
--- a/src/frontend/src/NavBar.js
+++ b/src/frontend/src/NavBar.js
@@ -16,10 +16,11 @@ export default function NavBar() {
     const currentPage = routeMatch?.pattern?.path;
 
     return (
-        <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3} style={{zIndex: 3}}>
+        <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3} style={{ zIndex: 3 }}>
             <BottomNavigation
                 value={currentPage}
                 showLabels
+                sx={{ paddingBottom: 'env(safe-area-inset-right)' }}
             >
                 <BottomNavigationAction label="Summary" icon={<AlignHorizontalLeftIcon />} value="/" to="/" component={Link} />
                 <BottomNavigationAction label="New Txn" icon={<AddBoxIcon />} value="/newTxn" to="/newTxn" component={Link} />

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -14,3 +14,8 @@ body {
 	flex-direction: column;
 	height: 100vh;
 }
+
+/* Expand the background of the bottom bar to match the height of the bar */
+#root > .MuiPaper-elevation {
+  box-sizing: initial!important;
+}


### PR DESCRIPTION
On new iPhones, the navigation bar was obscured by the home button slider. This PR adds a bit of padding to prevent this.