### PR TITLE
Periodically check if caches should be invalidated

### DIFF
--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -65,6 +65,15 @@ func main() {
 		log.Fatalf("Failed to update caches: %s", err)
 	}
 
+	go func(c *categorybudget.CategoryBudgets, b *budget.Budgets) {
+		for range time.Tick(time.Minute) {
+			err = f.InvalidateCacheIfAccountBalancesHaveChanged(c, b)
+			if err != nil {
+				fmt.Printf("Failed to check for stale cache: %s", err)
+			}
+		}
+	}(c, b)
+
 	log.Println("Listening for connections...")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
When I edit or input a transaction in Firefly-III, lychnos doesn't know about it. To keep the lychnos cache fresh, check the asset account balances in Firefly every minute (the request takes about 150ms for me). If any of the balances changed, then invalidate and refresh all the caches.

Future idea: it could be useful if the refresh interval were configurable.